### PR TITLE
fix: module selection shows its resources in action

### DIFF
--- a/internal/ui/actions.go
+++ b/internal/ui/actions.go
@@ -107,15 +107,16 @@ func (m Model) startAction() (tea.Model, tea.Cmd) {
 	ctx, cancel := context.WithCancel(context.Background())
 	m.cancel.fn = cancel
 
-	addrs := m.selectedAddresses()
 	m.outputLines = nil
 	m.workState = workAction
 	m.viewState = viewActionResources
 	m.offset = 0
-
 	m.actionStartTime = time.Now()
-	m.actionResources = make(map[string]*ActionResource, len(addrs))
-	for _, addr := range addrs {
+
+	resources := m.selectedResources()
+	m.actionResources = make(map[string]*ActionResource, len(resources))
+	for _, resource := range resources {
+		addr := resource.Address
 		m.actionResources[addr] = &ActionResource{
 			Address: addr,
 			Status:  actionResourcePending,
@@ -130,6 +131,7 @@ func (m Model) startAction() (tea.Model, tea.Cmd) {
 		"taint":   m.runner.Taint,
 		"untaint": m.runner.Untaint,
 	}
+	addrs := m.selectedAddresses()
 	ch := actionFuncs[action](ctx, addrs)
 	m.eventCh = ch
 

--- a/internal/ui/actions_test.go
+++ b/internal/ui/actions_test.go
@@ -211,3 +211,23 @@ func TestStartAction_PopulatesActionResources(t *testing.T) {
 	assert.Nil(t, m.outputLines)
 	assert.Equal(t, 0, m.offset)
 }
+
+func TestStartAction_ExpandsModuleSelection(t *testing.T) {
+	m := newTestModelWithResources([]terraform.Resource{
+		{Address: "module.a.aws_s3.x", Module: "module.a", Action: terraform.ActionCreate},
+		{Address: "module.a.aws_s3.y", Module: "module.a", Action: terraform.ActionCreate},
+		{Address: "aws_s3.outside", Action: terraform.ActionCreate},
+	})
+	m.runner = terraform.NewTerraformRunner(t.TempDir(), "true")
+	m.selected = map[string]bool{"module.a": true}
+
+	m.actionCursor = 1 // apply
+	m.viewState = viewConfirm
+	m.confirmCursor = 1
+	newModel, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	m = newModel.(Model)
+
+	assert.Len(t, m.actionResources, 2)
+	assert.Contains(t, m.actionResources, "module.a.aws_s3.x")
+	assert.Contains(t, m.actionResources, "module.a.aws_s3.y")
+}

--- a/internal/ui/actions_test.go
+++ b/internal/ui/actions_test.go
@@ -183,7 +183,11 @@ func TestGracefulQuit_CanCancelInitPull(t *testing.T) {
 }
 
 func TestStartAction_PopulatesActionResources(t *testing.T) {
-	m := NewModel(terraform.NewTerraformRunner(t.TempDir(), "true"))
+	m := newTestModelWithResources([]terraform.Resource{
+		{Address: "aws_s3_bucket.a", Action: terraform.ActionCreate},
+		{Address: "aws_s3_bucket.b", Action: terraform.ActionCreate},
+	})
+	m.runner = terraform.NewTerraformRunner(t.TempDir(), "true")
 	m.workState = workIdle
 	m.selected = map[string]bool{
 		"aws_s3_bucket.a": true,

--- a/internal/ui/render.go
+++ b/internal/ui/render.go
@@ -316,7 +316,7 @@ const (
 
 func (m Model) renderActionResourcesView() string {
 	action := actionChoices[m.actionCursor]
-	title := fmt.Sprintf("%sing %d resources...", action, len(m.selected))
+	title := fmt.Sprintf("%sing %d resources...", action, len(m.actionResources))
 
 	addrColWidth := max(1, m.viewWidth-statusColWidth-timeColWidth*3-10)
 	header := fmt.Sprintf("  %-*s  %-*s  %-*s  %-*s  %-*s",
@@ -338,11 +338,12 @@ func (m Model) renderActionResourcesView() string {
 		offset = 0
 	}
 
-	addrs := m.selectedAddresses()
+	resources := m.selectedResources()
 	visibleRows := max(1, m.viewHeight-4)
-	end := min(offset+visibleRows, len(addrs))
+	end := min(offset+visibleRows, len(resources))
 
-	for _, addr := range addrs[offset:end] {
+	for _, resource := range resources[offset:end] {
+		addr := resource.Address
 		ar := m.actionResources[addr]
 
 		displayAddr := addr

--- a/internal/ui/render_test.go
+++ b/internal/ui/render_test.go
@@ -257,7 +257,9 @@ func TestRenderActionResourcesView_DifferentResourceStates(t *testing.T) {
 
 func TestRenderActionResourcesView_TruncatesLongAddress(t *testing.T) {
 	longAddr := "module.very_long_module_name.module.another_long_name.aws_s3_bucket.extremely_long_bucket_name_that_exceeds_width"
-	m := newActionTestModel()
+	m := newTestModelWithResources([]terraform.Resource{
+		{Address: longAddr},
+	})
 	m.viewWidth = 60
 	m.selected = map[string]bool{longAddr: true}
 	m.actionResources = map[string]*ActionResource{

--- a/internal/ui/utils.go
+++ b/internal/ui/utils.go
@@ -33,6 +33,35 @@ func (m Model) selectedAddresses() []string {
 	return addrs
 }
 
+func (m Model) selectedResources() []*terraform.Resource {
+	var resources []*terraform.Resource
+	type stackElem struct {
+		item             *Item
+		ancestorSelected bool
+	}
+
+	stack := []stackElem{{item: m.rootItem, ancestorSelected: false}}
+	for len(stack) > 0 {
+		elem := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+
+		selected := elem.ancestorSelected || m.selected[elem.item.Address()]
+
+		if elem.item.IsResource() {
+			if selected {
+				resources = append(resources, elem.item.Resource)
+			}
+			continue
+		}
+
+		for _, child := range elem.item.Module.Children {
+			stack = append(stack, stackElem{item: child, ancestorSelected: selected})
+		}
+	}
+
+	return resources
+}
+
 // returns if it or ancestor module is selected
 func (m Model) isSelectedOrAncestor(item *Item) bool {
 	if m.selected[item.Address()] {

--- a/internal/ui/utils_test.go
+++ b/internal/ui/utils_test.go
@@ -3,8 +3,56 @@ package ui
 import (
 	"testing"
 
+	"github.com/SayYoungMan/tfui/pkg/terraform"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestSelectedResources_Empty(t *testing.T) {
+	m := newTestModelEmpty()
+
+	resources := m.selectedResources()
+
+	assert.Empty(t, resources)
+}
+
+func TestSelectedResources_OnlyResources(t *testing.T) {
+	m := newTestModelWithResources([]terraform.Resource{
+		{Address: "aws_s3.a", Action: terraform.ActionCreate},
+		{Address: "aws_s3.b", Action: terraform.ActionCreate},
+		{Address: "aws_s3.c", Action: terraform.ActionCreate},
+	})
+	m.selected = map[string]bool{"aws_s3.a": true, "aws_s3.c": true}
+
+	resources := m.selectedResources()
+
+	addrs := make([]string, len(resources))
+	for i, r := range resources {
+		addrs[i] = r.Address
+	}
+	assert.Len(t, resources, 2)
+	assert.Contains(t, addrs, "aws_s3.a")
+	assert.Contains(t, addrs, "aws_s3.c")
+}
+
+func TestSelectedResources_NestedModules(t *testing.T) {
+	m := newTestModelWithResources([]terraform.Resource{
+		{Address: "module.a.module.b.aws_s3.x", Module: "module.a.module.b", Action: terraform.ActionCreate},
+		{Address: "module.a.module.b.aws_s3.y", Module: "module.a.module.b", Action: terraform.ActionCreate},
+		{Address: "module.a.aws_s3.z", Module: "module.a", Action: terraform.ActionCreate},
+	})
+	m.selected = map[string]bool{"module.a": true}
+
+	resources := m.selectedResources()
+
+	addrs := make([]string, len(resources))
+	for i, r := range resources {
+		addrs[i] = r.Address
+	}
+	assert.Len(t, resources, 3)
+	assert.Contains(t, addrs, "module.a.module.b.aws_s3.x")
+	assert.Contains(t, addrs, "module.a.module.b.aws_s3.y")
+	assert.Contains(t, addrs, "module.a.aws_s3.z")
+}
 
 func TestAdjustOffset(t *testing.T) {
 	visible := 48 - defaultReservedRows - 1


### PR DESCRIPTION
Fixes broken behaviour for module selection due to action message only being about its resources.
Fixes #18 