### PR TITLE
fix: record errors and diagnostics during action mode

### DIFF
--- a/internal/ui/events.go
+++ b/internal/ui/events.go
@@ -98,6 +98,16 @@ func (m Model) handleActionEvent(event terraform.StreamEvent) (tea.Model, tea.Cm
 		m.outputLines = append(m.outputLines, event.Message)
 	}
 
+	if event.Error != nil {
+		m.err = event.Error
+		return m, waitForEvent(m.eventCh)
+	}
+
+	if event.Diagnostic != nil {
+		m.diagnostics = append(m.diagnostics, *event.Diagnostic)
+		return m, waitForEvent(m.eventCh)
+	}
+
 	if event.Resource == nil {
 		return m, waitForEvent(m.eventCh)
 	}

--- a/internal/ui/events_test.go
+++ b/internal/ui/events_test.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -126,6 +127,52 @@ func TestHandleActionEvent_NilResource(t *testing.T) {
 	m = newModel.(Model)
 
 	assert.NotNil(t, cmd)
+}
+
+func TestHandleActionEvent_RecordsError(t *testing.T) {
+	m := newActionTestModel()
+	wantErr := errors.New("terraform apply exited with error: exit status 1")
+
+	newModel, cmd := m.Update(streamEventMsg(terraform.StreamEvent{
+		Error: wantErr,
+	}))
+	m = newModel.(Model)
+
+	assert.Equal(t, wantErr, m.err)
+	assert.NotNil(t, cmd)
+}
+
+func TestHandleActionEvent_RecordsDiagnostic(t *testing.T) {
+	m := newActionTestModel()
+
+	newModel, cmd := m.Update(streamEventMsg(terraform.StreamEvent{
+		Diagnostic: &terraform.Diagnostic{
+			Severity: "error",
+			Summary:  "Invalid value for variable",
+			Detail:   "no value provided",
+		},
+	}))
+	m = newModel.(Model)
+
+	require.Len(t, m.diagnostics, 1)
+	assert.Equal(t, "error", m.diagnostics[0].Severity)
+	assert.Equal(t, "Invalid value for variable", m.diagnostics[0].Summary)
+	assert.NotNil(t, cmd)
+}
+
+func TestHandleActionEvent_ErrorRoutesToErrorView(t *testing.T) {
+	m := newActionTestModel()
+
+	newModel, _ := m.Update(streamEventMsg(terraform.StreamEvent{
+		Error: errors.New("apply failed"),
+	}))
+	m = newModel.(Model)
+
+	newModel, _ = m.Update(streamCompleteMsg{})
+	m = newModel.(Model)
+
+	assert.Equal(t, viewError, m.viewState)
+	assert.True(t, m.hasError())
 }
 
 func TestHandleActionEvent_AppendsMessage(t *testing.T) {


### PR DESCRIPTION
## Summary

- `handleActionEvent` returned early on `event.Resource == nil`, so terraform `Error` and `Diagnostic` events emitted during apply/destroy were silently dropped.
- After this fix, action-mode errors and diagnostics are accumulated into `m.err` / `m.diagnostics` (same pattern the plan-mode handler already uses), so `hasError()` sees them and `streamCompleteMsg` routes the user to the error view.

## Test plan

- [x] New unit tests in `internal/ui/events_test.go`:
  - `TestHandleActionEvent_RecordsError` — action stream emits `event.Error`, `m.err` is set.
  - `TestHandleActionEvent_RecordsDiagnostic` — action stream emits `event.Diagnostic`, `m.diagnostics` grows.
  - `TestHandleActionEvent_ErrorRoutesToErrorView` — after error + `streamCompleteMsg`, `viewState == viewError` and `hasError()` returns true.
- [x] Existing 190 tests still pass under `go test -race ./...`.
- [x] `go vet ./...` clean.

## Notes

Fixes #24. This is one of three PRs landing the highest-priority bugs from the recent stabilization review; the others address selection/target divergence (#25) and the unhandled `planned_change`/`resource_drift` event types in action mode (#26).

The fix intentionally mirrors the existing plan-mode handler's last-write-wins behavior for `m.err`. A separate change to preserve the first error (issue #34) can layer on top.