### PR TITLE
fix: resolve selection against full resource set, not filtered tree

### DIFF
--- a/internal/ui/actions_test.go
+++ b/internal/ui/actions_test.go
@@ -212,6 +212,28 @@ func TestStartAction_PopulatesProgress(t *testing.T) {
 	assert.Equal(t, 0, m.offset)
 }
 
+func TestStartAction_HiddenSelectionStillTracked(t *testing.T) {
+	m := newTestModelWithResources([]*terraform.Resource{
+		{Address: "aws_s3.hidden", Action: terraform.ActionCreate},
+		{Address: "aws_lambda.visible", Action: terraform.ActionCreate},
+	})
+	m.runner = terraform.NewTerraformRunner(t.TempDir(), "true")
+	m.selected = map[string]bool{"aws_s3.hidden": true}
+
+	m.filterInput.SetValue("lambda")
+	m.rebuildRows()
+
+	m.actionCursor = 1 // apply
+	m.viewState = viewConfirm
+	m.confirmCursor = 1
+	newModel, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	m = newModel.(Model)
+
+	assert.Equal(t, viewProgress, m.viewState)
+	assert.Len(t, m.progresses, 1)
+	assert.Contains(t, m.progresses, "aws_s3.hidden")
+}
+
 func TestStartAction_ExpandsModuleSelection(t *testing.T) {
 	m := newTestModelWithResources([]*terraform.Resource{
 		{Address: "module.a.aws_s3.x", Module: "module.a", Action: terraform.ActionCreate},

--- a/internal/ui/render.go
+++ b/internal/ui/render.go
@@ -8,7 +8,8 @@ import (
 )
 
 func (m Model) renderActionPickerView() string {
-	title := fmt.Sprintf("%d resource(s) selected", len(m.selected))
+	resolved := m.selectedResources()
+	title := fmt.Sprintf("%d resource(s) selected", len(resolved))
 	keyInfo := []keyInfo{
 		{key: "Enter", info: "select"},
 		{key: "Esc", info: "cancel"},
@@ -39,33 +40,29 @@ func (m Model) renderActionPickerView() string {
 
 func (m Model) renderConfirmView() string {
 	chosenAction := actionChoices[m.actionCursor]
-	title := fmt.Sprintf("⚠  %s %d resource(s)?", chosenAction, len(m.selected))
+	resolved := m.selectedResources()
+	title := fmt.Sprintf("⚠  %s %d resource(s)?", chosenAction, len(resolved))
 
 	// For viewHeight >= 20, show max 10 resource names
 	// For viewHeight 12~19, show max 1~9 resource names
 	// For viewHeight < 12, show just 1 resource name max
 	maxResourceRows := max(min(10, m.viewHeight-10), 1)
 
-	addrs := m.selectedAddresses()
-	if len(addrs) > maxResourceRows {
-		addrs = addrs[:maxResourceRows]
+	shown := resolved
+	if len(shown) > maxResourceRows {
+		shown = shown[:maxResourceRows]
 	}
 
 	var resourceLines []string
-	for _, addr := range addrs {
-		var line string
-		if r, isResource := m.resources[addr]; isResource {
-			line = fmt.Sprintf("  %s %s", r.Action.Symbol(), addr)
-			if style, ok := actionStyles[r.Action]; ok {
-				line = style.Render(line)
-			}
-		} else {
-			line = fmt.Sprintf("    %s", addr)
+	for _, r := range shown {
+		line := fmt.Sprintf("  %s %s", r.Action.Symbol(), r.Address)
+		if style, ok := actionStyles[r.Action]; ok {
+			line = style.Render(line)
 		}
 		resourceLines = append(resourceLines, line)
 	}
 
-	truncated := len(m.selected) - len(addrs)
+	truncated := len(resolved) - len(shown)
 	if truncated > 0 {
 		resourceLines = append(resourceLines, dimStyle.Render(fmt.Sprintf("    ... and %d more", truncated)))
 	}

--- a/internal/ui/render_test.go
+++ b/internal/ui/render_test.go
@@ -183,6 +183,54 @@ func TestRenderConfirmView_ShowsResourcesAndButtons(t *testing.T) {
 	assert.Contains(t, view.Content, "Confirm")
 }
 
+func TestRenderActionPickerView_CountExpandsModuleSelection(t *testing.T) {
+	m := newTestModelWithResources([]*terraform.Resource{
+		{Address: "module.a.aws_s3.x", Module: "module.a", Action: terraform.ActionCreate},
+		{Address: "module.a.aws_s3.y", Module: "module.a", Action: terraform.ActionCreate},
+		{Address: "module.a.aws_s3.z", Module: "module.a", Action: terraform.ActionCreate},
+	})
+	m.viewState = viewActionPicker
+	m.selected = map[string]bool{"module.a": true}
+
+	view := m.View()
+
+	assert.Contains(t, view.Content, "3 resource(s) selected")
+}
+
+func TestRenderConfirmView_ModuleSelectionListsExpandedResources(t *testing.T) {
+	m := newTestModelWithResources([]*terraform.Resource{
+		{Address: "module.a.aws_s3.x", Module: "module.a", Action: terraform.ActionCreate},
+		{Address: "module.a.aws_s3.y", Module: "module.a", Action: terraform.ActionCreate},
+	})
+	m.viewState = viewConfirm
+	m.actionCursor = 1 // apply
+	m.selected = map[string]bool{"module.a": true}
+
+	view := m.View()
+
+	assert.Contains(t, view.Content, "apply 2 resource(s)?")
+	assert.Contains(t, view.Content, "module.a.aws_s3.x")
+	assert.Contains(t, view.Content, "module.a.aws_s3.y")
+}
+
+func TestRenderConfirmView_HiddenSelectionStillCounted(t *testing.T) {
+	m := newTestModelWithResources([]*terraform.Resource{
+		{Address: "aws_s3.hidden", Action: terraform.ActionCreate},
+		{Address: "aws_lambda.visible", Action: terraform.ActionCreate},
+	})
+	m.viewState = viewConfirm
+	m.actionCursor = 1 // apply
+	m.selected = map[string]bool{"aws_s3.hidden": true}
+
+	m.filterInput.SetValue("lambda")
+	m.rebuildRows()
+
+	view := m.View()
+
+	assert.Contains(t, view.Content, "apply 1 resource(s)?")
+	assert.Contains(t, view.Content, "aws_s3.hidden")
+}
+
 func TestRenderConfirmView_TruncatesLongSelections(t *testing.T) {
 	m := newTestModelEmpty()
 	m.viewState = viewConfirm

--- a/internal/ui/utils.go
+++ b/internal/ui/utils.go
@@ -33,33 +33,37 @@ func (m Model) selectedAddresses() []string {
 	return addrs
 }
 
+// selectedResources returns the resources that would actually be acted on,
+// independent of filter and "hide unchanged". Selection is resolved against
+// m.resources (the full known set), so the picker / confirm / progress views
+// and the terraform target list agree regardless of which rows are currently
+// visible.
 func (m Model) selectedResources() []*terraform.Resource {
-	var resources []*terraform.Resource
-	type stackElem struct {
-		item             *Item
-		ancestorSelected bool
-	}
-
-	stack := []stackElem{{item: m.rootItem, ancestorSelected: false}}
-	for len(stack) > 0 {
-		elem := stack[len(stack)-1]
-		stack = stack[:len(stack)-1]
-
-		selected := elem.ancestorSelected || m.selected[elem.item.Address()]
-
-		if elem.item.IsResource() {
-			if selected {
-				resources = append(resources, elem.item.Resource)
-			}
+	resources := make([]*terraform.Resource, 0, len(m.selected))
+	for addr, r := range m.resources {
+		if !m.isAddressInSelection(addr) {
 			continue
 		}
+		resources = append(resources, r)
+	}
+	sort.Slice(resources, func(i, j int) bool {
+		return resources[i].Address < resources[j].Address
+	})
+	return resources
+}
 
-		for _, child := range elem.item.Module.Children {
-			stack = append(stack, stackElem{item: child, ancestorSelected: selected})
+// isAddressInSelection reports whether the resource at addr is selected
+// directly or sits under a selected ancestor module.
+func (m Model) isAddressInSelection(addr string) bool {
+	if m.selected[addr] {
+		return true
+	}
+	for parent := parentModuleAddr(addr); parent != ""; parent = parentModuleAddr(parent) {
+		if m.selected[parent] {
+			return true
 		}
 	}
-
-	return resources
+	return false
 }
 
 // returns if it or ancestor module is selected

--- a/internal/ui/utils_test.go
+++ b/internal/ui/utils_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/SayYoungMan/tfui/pkg/terraform"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSelectedResources_Empty(t *testing.T) {
@@ -32,6 +33,67 @@ func TestSelectedResources_OnlyResources(t *testing.T) {
 	assert.Len(t, resources, 2)
 	assert.Contains(t, addrs, "aws_s3.a")
 	assert.Contains(t, addrs, "aws_s3.c")
+}
+
+func TestSelectedResources_IndependentOfFilter(t *testing.T) {
+	m := newTestModelWithResources([]*terraform.Resource{
+		{Address: "aws_s3.a", Action: terraform.ActionCreate},
+		{Address: "aws_lambda.b", Action: terraform.ActionCreate},
+	})
+	m.selected = map[string]bool{"aws_s3.a": true}
+
+	m.filterInput.SetValue("lambda")
+	m.rebuildRows()
+	for _, row := range m.rows {
+		require.NotEqual(t, "aws_s3.a", row.Item.Address(), "filter should hide aws_s3.a from the visible tree")
+	}
+
+	resources := m.selectedResources()
+
+	require.Len(t, resources, 1)
+	assert.Equal(t, "aws_s3.a", resources[0].Address)
+}
+
+func TestSelectedResources_IndependentOfHideUnchanged(t *testing.T) {
+	m := newTestModelWithResources([]*terraform.Resource{
+		{Address: "aws_s3.a", Action: terraform.ActionNoop},
+	})
+	m.selected = map[string]bool{"aws_s3.a": true}
+
+	m.hideUnchanged = true
+	m.rebuildRows()
+	require.Empty(t, m.rows, "hideUnchanged should hide the no-op resource")
+
+	resources := m.selectedResources()
+
+	require.Len(t, resources, 1)
+	assert.Equal(t, "aws_s3.a", resources[0].Address)
+}
+
+func TestIsAddressInSelection(t *testing.T) {
+	m := newTestModelEmpty()
+	m.selected = map[string]bool{
+		"aws_s3.direct":          true,
+		"module.a":               true,
+		"module.b.module.nested": true,
+	}
+
+	tests := []struct {
+		addr     string
+		expected bool
+	}{
+		{"aws_s3.direct", true},
+		{"module.a.aws_s3.x", true},
+		{"module.a.module.b.aws_s3.y", true},
+		{"module.b.module.nested.aws_s3.z", true},
+		{"module.b.aws_s3.unrelated", false},
+		{"aws_s3.unselected", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.addr, func(t *testing.T) {
+			assert.Equal(t, tt.expected, m.isAddressInSelection(tt.addr))
+		})
+	}
 }
 
 func TestSelectedResources_NestedModules(t *testing.T) {


### PR DESCRIPTION
## Summary

Before:
- `selectedResources()` walked `m.rootItem` (the filtered / hide-unchanged tree).
- `selectedAddresses()` used the raw `m.selected` map.
- Picker and confirm titles used `len(m.selected)` directly.

Three divergent sources, three observable bugs:

1. **Hidden-by-filter selections still get applied silently.** Select `aws_s3.a`, type `/lambda` to filter it out, exit filter, Tab → apply → Confirm. Terraform gets `-target=aws_s3.a`, but `m.progresses` is empty, so events for it hit the unknown-address skip in `handleActionEvent`. Progress view shows 0 resources; terraform actually changed the resource.
2. **Module selections show wrong count.** Select `module.foo` containing 5 children. Picker says \"1 resource(s) selected\"; confirm says \"apply 1 resource(s)?\". Terraform applies all 5 + dependencies.
3. **Confirm body for module selections shows the module address with no action symbol.**

## Fix

- Rewrite `selectedResources()` to walk `m.resources` directly. For each resource address, expand selection via `parentModuleAddr` ancestry. Result is independent of the filter / hide-unchanged tree.
- Extract `isAddressInSelection(addr)` so the membership check is named.
- Update `renderActionPickerView` and `renderConfirmView` to use `len(m.selectedResources())`.
- Update `renderConfirmView` body to iterate the resolved set — user now sees exactly what will run, with action symbols.

`selectedAddresses()` is unchanged: it still returns the raw selection, which is what gets passed to terraform via `-target`. This preserves module-level targeting semantics (so \"apply module.foo\" stays \"apply module.foo\" to terraform). The progress map now keys off the resolved set, so events for module children land in the right place regardless of how the parent was selected.

## Test plan

New unit tests:

- `TestSelectedResources_IndependentOfFilter` — selected resource hidden by filter still appears in resolved set.
- `TestSelectedResources_IndependentOfHideUnchanged` — same, hidden by `H` toggle.
- `TestIsAddressInSelection` — exhaustive membership check including nested modules.
- `TestRenderActionPickerView_CountExpandsModuleSelection` — title shows expanded count.
- `TestRenderConfirmView_ModuleSelectionListsExpandedResources` — body shows children, not the module address.
- `TestRenderConfirmView_HiddenSelectionStillCounted` — hidden-by-filter selection appears in confirm modal.
- `TestStartAction_HiddenSelectionStillTracked` — end-to-end: filter hides selection, then apply, `m.progresses` contains the hidden resource.

Plus all existing tests still pass (`go test -race ./...` reports 203 passed; `go vet` clean).

Fixes #25.