### PR TITLE
fix: handle planned_change and resource_drift during action mode

### DIFF
--- a/internal/ui/events.go
+++ b/internal/ui/events.go
@@ -102,7 +102,28 @@ func (m Model) handleActionEvent(event terraform.StreamEvent) (tea.Model, tea.Cm
 		return m, waitForEvent(m.eventCh)
 	}
 
-	ar, ok := m.progresses[event.Resource.Address]
+	addr := event.Resource.Address
+
+	// planned_change / resource_drift carry the resource's new Action and Reason.
+	// Mirror those into m.resources so the list view reflects the latest plan,
+	// and create a Progress entry if the resource is under the active selection
+	// — e.g. a brand-new resource discovered inside a selected module that wasn't
+	// in state at startAction time.
+	if event.Type == terraform.MsgTypePlannedChange || event.Type == terraform.MsgTypeResourceDrift {
+		if existing, exists := m.resources[addr]; exists {
+			event.Resource.Attributes = existing.Attributes
+		}
+		m.resources[addr] = event.Resource
+		if _, tracked := m.progresses[addr]; !tracked && m.isUnderActiveSelection(addr) {
+			m.progresses[addr] = &Progress{
+				Address: addr,
+				Status:  progressStatusPending,
+			}
+		}
+		return m, waitForEvent(m.eventCh)
+	}
+
+	ar, ok := m.progresses[addr]
 	if !ok {
 		// There are some apply_start and apply_complete from data sources that are not selected
 		return m, waitForEvent(m.eventCh)

--- a/internal/ui/events_test.go
+++ b/internal/ui/events_test.go
@@ -128,6 +128,126 @@ func TestHandleActionEvent_NilResource(t *testing.T) {
 	assert.NotNil(t, cmd)
 }
 
+func TestHandleActionEvent_PlannedChangeUpdatesResources(t *testing.T) {
+	m := newActionTestModel()
+	m.resources[testAddr] = &terraform.Resource{
+		Address: testAddr,
+		Action:  terraform.ActionNoop,
+	}
+
+	newModel, cmd := m.Update(streamEventMsg(terraform.StreamEvent{
+		Type: terraform.MsgTypePlannedChange,
+		Resource: &terraform.Resource{
+			Address: testAddr,
+			Action:  terraform.ActionUpdate,
+			Reason:  "drift",
+		},
+	}))
+	m = newModel.(Model)
+
+	require.NotNil(t, cmd)
+	assert.Equal(t, terraform.ActionUpdate, m.resources[testAddr].Action)
+	assert.Equal(t, "drift", m.resources[testAddr].Reason)
+}
+
+func TestHandleActionEvent_ResourceDriftUpdatesResources(t *testing.T) {
+	m := newActionTestModel()
+	m.resources[testAddr] = &terraform.Resource{
+		Address: testAddr,
+		Action:  terraform.ActionNoop,
+	}
+
+	newModel, _ := m.Update(streamEventMsg(terraform.StreamEvent{
+		Type: terraform.MsgTypeResourceDrift,
+		Resource: &terraform.Resource{
+			Address: testAddr,
+			Action:  terraform.ActionUpdate,
+		},
+	}))
+	m = newModel.(Model)
+
+	assert.Equal(t, terraform.ActionUpdate, m.resources[testAddr].Action)
+}
+
+func TestHandleActionEvent_PlannedChangeCreatesProgressForSelectedResource(t *testing.T) {
+	m := newActionTestModel()
+	newAddr := "aws_s3_bucket.brand_new"
+	m.selected = map[string]bool{newAddr: true}
+
+	newModel, _ := m.Update(streamEventMsg(terraform.StreamEvent{
+		Type: terraform.MsgTypePlannedChange,
+		Resource: &terraform.Resource{
+			Address: newAddr,
+			Action:  terraform.ActionCreate,
+		},
+	}))
+	m = newModel.(Model)
+
+	require.Contains(t, m.progresses, newAddr)
+	assert.Equal(t, progressStatusPending, m.progresses[newAddr].Status)
+	assert.Equal(t, newAddr, m.progresses[newAddr].Address)
+}
+
+func TestHandleActionEvent_PlannedChangeCreatesProgressUnderSelectedModule(t *testing.T) {
+	m := newActionTestModel()
+	newAddr := "module.foo.aws_s3.brand_new"
+	m.selected = map[string]bool{"module.foo": true}
+
+	newModel, _ := m.Update(streamEventMsg(terraform.StreamEvent{
+		Type: terraform.MsgTypePlannedChange,
+		Resource: &terraform.Resource{
+			Address: newAddr,
+			Module:  "module.foo",
+			Action:  terraform.ActionCreate,
+		},
+	}))
+	m = newModel.(Model)
+
+	require.Contains(t, m.progresses, newAddr)
+	assert.Equal(t, progressStatusPending, m.progresses[newAddr].Status)
+}
+
+func TestHandleActionEvent_PlannedChangeNoProgressForUnselectedResource(t *testing.T) {
+	m := newActionTestModel()
+	unrelated := "aws_s3_bucket.unrelated"
+
+	newModel, _ := m.Update(streamEventMsg(terraform.StreamEvent{
+		Type: terraform.MsgTypePlannedChange,
+		Resource: &terraform.Resource{
+			Address: unrelated,
+			Action:  terraform.ActionCreate,
+		},
+	}))
+	m = newModel.(Model)
+
+	// m.resources still updated so list view reflects the new plan after the action.
+	assert.Equal(t, terraform.ActionCreate, m.resources[unrelated].Action)
+	// No progress entry — resource isn't under the active selection.
+	assert.NotContains(t, m.progresses, unrelated)
+}
+
+func TestHandleActionEvent_PlannedChangePreservesAttributes(t *testing.T) {
+	m := newActionTestModel()
+	m.resources[testAddr] = &terraform.Resource{
+		Address:    testAddr,
+		Action:     terraform.ActionNoop,
+		Attributes: []byte(`{"id":"existing"}`),
+	}
+
+	newModel, _ := m.Update(streamEventMsg(terraform.StreamEvent{
+		Type: terraform.MsgTypePlannedChange,
+		Resource: &terraform.Resource{
+			Address: testAddr,
+			Action:  terraform.ActionUpdate,
+			// Attributes intentionally nil — should be preserved from existing
+		},
+	}))
+	m = newModel.(Model)
+
+	assert.Equal(t, terraform.ActionUpdate, m.resources[testAddr].Action)
+	assert.JSONEq(t, `{"id":"existing"}`, string(m.resources[testAddr].Attributes))
+}
+
 func TestHandleActionEvent_AppendsMessage(t *testing.T) {
 	m := newActionTestModel()
 

--- a/internal/ui/utils.go
+++ b/internal/ui/utils.go
@@ -24,6 +24,20 @@ func isUnchanged(r *terraform.Resource) bool {
 	return r.Action == terraform.ActionNoop || r.Action == terraform.ActionRead || r.Action == terraform.ActionUncertain
 }
 
+// isUnderActiveSelection reports whether the resource at addr is selected
+// directly or sits under a selected ancestor module.
+func (m Model) isUnderActiveSelection(addr string) bool {
+	if m.selected[addr] {
+		return true
+	}
+	for parent := parentModuleAddr(addr); parent != ""; parent = parentModuleAddr(parent) {
+		if m.selected[parent] {
+			return true
+		}
+	}
+	return false
+}
+
 func (m Model) selectedAddresses() []string {
 	addrs := make([]string, 0, len(m.selected))
 	for addr := range m.selected {


### PR DESCRIPTION
## Summary

`handleActionEvent` only switched on hook event types (`refresh_*` / `apply_*`). `planned_change` and `resource_drift` events arriving during a plan-as-action were silently dropped, producing two observable bugs:

1. **List view stale after plan-as-action.** Select resources, Tab → plan → Confirm; the targeted plan runs, but `m.resources[addr]` is never updated with the new Action/Reason from the `planned_change` events. After the action ends, the list shows the pre-action state.

2. **New resources display as \"No change\".** A resource added to `.tf` since the initial state pull has no refresh phase, so its only event is `planned_change`. Ignored → status stays `Pending` → `streamCompleteMsg` converts `Pending → Skipped` → progress view shows \"— No change\" for what is actually a fresh create.

## Fix

In `handleActionEvent`, treat `planned_change` / `resource_drift` as update-the-model events:

- Mirror `m.resources[addr] = event.Resource`, preserving cached `Attributes` the same way the plan-mode handler does.
- If the resource is under the active selection (direct or via ancestor module), create a `Progress` entry. This means subsequent hook events for it find their tracking row instead of hitting the unknown-address skip later in the same handler.

Adds `isUnderActiveSelection(addr)` helper for the membership check — walks the parent module ancestry against `m.selected`, identical in shape to the existing `isAncestor` but predicated against the selected map.

## Test plan

New unit tests in `internal/ui/events_test.go`:

- `TestHandleActionEvent_PlannedChangeUpdatesResources` — `m.resources[addr]` gets the new Action/Reason.
- `TestHandleActionEvent_ResourceDriftUpdatesResources` — same for `resource_drift`.
- `TestHandleActionEvent_PlannedChangeCreatesProgressForSelectedResource` — directly-selected fresh resource gets a Pending Progress entry.
- `TestHandleActionEvent_PlannedChangeCreatesProgressUnderSelectedModule` — fresh resource under a selected module also gets one.
- `TestHandleActionEvent_PlannedChangeNoProgressForUnselectedResource` — `m.resources` still updated, but no Progress entry created (correct — we only track what was selected).
- `TestHandleActionEvent_PlannedChangePreservesAttributes` — JSON attributes from state pull survive the merge.

All existing tests still pass (`go test -race ./...`, 196 passed). `go vet` clean.

## Notes

Fixes #26.

Related: this is the third of three PRs landing the highest-priority bugs from the recent stabilization review (the others are #36 for issue #24 and #37 for issue #25).

There is overlap with #37: both PRs add a helper that walks `parentModuleAddr` ancestry against `m.selected` — `isUnderActiveSelection` here and `isAddressInSelection` there. The implementations are identical; when both land, a follow-up cleanup can deduplicate (keep one name). They don't conflict for individual review.